### PR TITLE
PostgreSQL i Nais - To steg frem og ett tilbake

### DIFF
--- a/src/routes/(pages)/log/posts/2026-04-29-postgresql-i-nais-to-steg-frem-og-ett-tilbake.md
+++ b/src/routes/(pages)/log/posts/2026-04-29-postgresql-i-nais-to-steg-frem-og-ett-tilbake.md
@@ -6,7 +6,7 @@ tags: [postgres, cloudsql, experimental]
 layout: log
 ---
 
-Som vi annonserte i [juni i fjor](2025-06-23-en-ny-m%C3%A5te-%C3%A5-kj%C3%B8re-postgres-i-nais.md), så jobber vi med en helt ny måte å kjøre PostgreSQL i nais.
+Som vi annonserte i [juni i fjor](2025-06-23-en-ny-m%C3%A5te-%C3%A5-kj%C3%B8re-postgres-i-nais.md), så jobber vi med en helt ny måte å kjøre PostgreSQL i Nais.
 
 I løpet av året har vi lært mye, implementert og endret mye i bakgrunnen og gradvis bygget opp løsningen til noe som nærmer seg produksjonsklart.
 
@@ -22,6 +22,7 @@ Etter at vi fant ut at vi ikke var helt fornøyd med Zalando så tok vi en kort 
 Konklusjonen etter den testen er at vi har lyst til å prøve cloudnative-pg i stedet for Zalandos postgres-operator.
 
 Det betyr at vi må ta noen steg tilbake og skrive om en del av det vi har gjort så langt, og eksisterende pilotbrukere vil være nødt til å migrere databasene sine når vi kommer så langt.
+Inntil vi er klare med endringene så ønsker vi at teamene venter med å opprette *nye* databaser på denne løsningen.
 
 Planen nå er at vi frem mot sommeren skal jobbe med å implementere cloudnative-pg i plattformen der vi tidligere har brukt Zalando postgres-operator.
 Eksisterende brukere vil kunne fortsette med de basene de har inntil videre, men vil nok bli anmodet om å migrere etter sommeren en gang.

--- a/src/routes/(pages)/log/posts/2026-04-29-postgresql-i-nais-to-steg-frem-og-ett-tilbake.md
+++ b/src/routes/(pages)/log/posts/2026-04-29-postgresql-i-nais-to-steg-frem-og-ett-tilbake.md
@@ -28,4 +28,4 @@ Planen nå er at vi frem mot sommeren skal jobbe med å implementere cloudnative
 Eksisterende brukere vil kunne fortsette med de basene de har inntil videre, men vil nok bli anmodet om å migrere etter sommeren en gang.
 Vi kommer til å se på om det kan gjøres automatisk på noe vis, vi vil kontakte aktuelle team med mer detaljer når det er klart.
 
-Håpet er at vi etter sommeren skal være ganske nære å kunne si at disse databasene er produksjonsklare.
+Vi forventer å ha produksjonsklare databaser tilgjengelig tidlig i høst.

--- a/src/routes/(pages)/log/posts/2026-04-29-postgresql-i-nais-to-steg-frem-og-ett-tilbake.md
+++ b/src/routes/(pages)/log/posts/2026-04-29-postgresql-i-nais-to-steg-frem-og-ett-tilbake.md
@@ -1,0 +1,30 @@
+---
+title: "PostgreSQL i Nais - To steg frem og ett tilbake"
+date: 2026-04-29T09:27:00+02:00
+author: Morten Lied Johansen
+tags: [postgres, cloudsql, experimental]
+layout: log
+---
+
+Som vi annonserte i [juni i fjor](2025-06-23-en-ny-m%C3%A5te-%C3%A5-kj%C3%B8re-postgres-i-nais.md), så jobber vi med en helt ny måte å kjøre PostgreSQL i nais.
+
+I løpet av året har vi lært mye, implementert og endret mye i bakgrunnen og gradvis bygget opp løsningen til noe som nærmer seg produksjonsklart.
+
+For ca. 8 uker siden tok vi en fot i bakken og oppsummerte hva vi hadde lært, hva vi følte manglet, og hvordan vi skulle fortsette.
+Oppsummeringen er at vi har fortsatt god tro på at det er mye å hente på å kjøre PostgreSQL i clusterne, både i form av kostnadsbesparelse, utvikleropplevelse og plattformdrift.
+Vi er også ganske fornøyd med utviklergrensesnittet vi har lagt opp til, med en `Postgres` ressurs som beskriver databasen og en referanse fra `Application`/`Naisjob`.
+
+Det vi derimot har mistet litt troen på er at Zalando sin postgres-operator er veien å gå.
+Zalando har skiftet fokus til å kun fokusere på sine egne behov (og ikke open-source community), og der vi opplever problemer med operatoren så er det avhengig av at Zalando har det samme problemet for at det skal bli tatt tak i.
+
+Før vi landet på Zalando i første omgang så evaluerte vi også [cloudnative-pg](https://cloudnative-pg.io), men kom til at prosjektet var for ungt og ustabilt.
+Etter at vi fant ut at vi ikke var helt fornøyd med Zalando så tok vi en kort test av cloudnative-pg, for å se om de hadde løst noen av problemene vi fant i forrige evaluering for godt over et år siden.
+Konklusjonen etter den testen er at vi har lyst til å prøve cloudnative-pg i stedet for Zalandos postgres-operator.
+
+Det betyr at vi må ta noen steg tilbake og skrive om en del av det vi har gjort så langt, og eksisterende pilotbrukere vil være nødt til å migrere databasene sine når vi kommer så langt.
+
+Planen nå er at vi frem mot sommeren skal jobbe med å implementere cloudnative-pg i plattformen der vi tidligere har brukt Zalando postgres-operator.
+Eksisterende brukere vil kunne fortsette med de basene de har inntil videre, men vil nok bli anmodet om å migrere etter sommeren en gang.
+Vi kommer til å se på om det kan gjøres automatisk på noe vis, vi vil kontakte aktuelle team med mer detaljer når det er klart.
+
+Håpet er at vi etter sommeren skal være ganske nære å kunne si at disse databasene er produksjonsklare.


### PR DESCRIPTION
En post om endringen i retning for PostgreSQL i Nais.
Vi slapp katten ut av sekken i en tråd i #nais i går, så det er på sin plass å informere litt bredere om hva som skjer og hva som er planen fremover.

[Rendered](https://github.com/nais/nais.github.io/blob/postgres-cnpg-switch/src/routes/(pages)/log/posts/2026-04-29-postgresql-i-nais-to-steg-frem-og-ett-tilbake.md)